### PR TITLE
Fixed @debug syntax to avoid errors

### DIFF
--- a/bluegrid/grid/_classes.scss
+++ b/bluegrid/grid/_classes.scss
@@ -39,7 +39,8 @@
 }
 
 @if _bluegrid('do-compile-classes') {
-  @debug: 'what';
+  @debug 'what';
+}
 
 .container-fluid, .fluid-container {
   margin-right: auto;


### PR DESCRIPTION
Hi. I saw the @debug was written with a colon (:) after it and the @if _bluegrid() statement had no closing brace. This caused my own Sass compiler to break and I've fixed it here
